### PR TITLE
feat: Add necessary features so buddy-alloc can be used as std's deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,13 @@ description = "Buddy-alloc is a memory allocator for no-std Rust, used for embed
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+rustc-dep-of-std = ["core", "compiler_builtins/rustc-dep-of-std"]
+
 [dependencies]
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ default: integration
 integration: check-fmt check clippy test run-example
 
 test:
-	cargo test --all --all-features ${TEST_ARGS} -- --nocapture
+	cargo test --all ${TEST_ARGS} -- --nocapture
 
 clippy:
-	cargo clippy --all --all-features --all-targets
+	cargo clippy --all --all-targets
 
 check-fmt:
 	cargo fmt --all -- --check

--- a/src/buddy_alloc.rs
+++ b/src/buddy_alloc.rs
@@ -187,6 +187,7 @@ impl BuddyAlloc {
         let end_addr = base_addr + len;
         assert!(
             leaf_size % MIN_LEAF_SIZE_ALIGN == 0 && leaf_size != 0,
+            "{}",
             LEAF_ALIGN_ERROR_MSG
         );
         let leaf2base = log2(leaf_size);
@@ -198,7 +199,7 @@ impl BuddyAlloc {
 
         // alloc buddy allocator memory
         let used_bytes = core::mem::size_of::<Entry>() * entries_size;
-        debug_assert!(end_addr >= base_addr + used_bytes, OOM_MSG);
+        debug_assert!(end_addr >= base_addr + used_bytes, "{}", OOM_MSG);
         let entries = base_addr as *mut Entry;
         base_addr += used_bytes;
 
@@ -206,7 +207,7 @@ impl BuddyAlloc {
         // init entries free
         for k in 0..entries_size {
             // use one bit for per memory block
-            debug_assert!(end_addr >= base_addr + buddy_list_size, OOM_MSG);
+            debug_assert!(end_addr >= base_addr + buddy_list_size, "{}", OOM_MSG);
             let entry = entries.add(k).as_mut().expect("entry");
             entry.free = base_addr as *mut Node;
             core::ptr::write_bytes(entry.free, 0, buddy_list_size);
@@ -219,7 +220,7 @@ impl BuddyAlloc {
             // use one bit for per memory block
             // use shift instead `/`, 8 == 1 << 3
             let used_bytes = roundup(nblock(k, entries_size), 3) >> 3;
-            debug_assert!(end_addr >= base_addr + used_bytes, OOM_MSG);
+            debug_assert!(end_addr >= base_addr + used_bytes, "{}", OOM_MSG);
             let entry = entries.add(k).as_mut().expect("entry");
             entry.alloc = base_addr as *mut u8;
             // mark all blocks as allocated
@@ -232,7 +233,7 @@ impl BuddyAlloc {
             // use one bit for per memory block
             // use shift instead `/`, 8 == 1 << 3
             let used_bytes = roundup(nblock(k, entries_size), 3) >> 3;
-            debug_assert!(end_addr >= base_addr + used_bytes, OOM_MSG);
+            debug_assert!(end_addr >= base_addr + used_bytes, "{}", OOM_MSG);
             let entry = entries.add(k).as_mut().expect("entry");
             entry.split = base_addr as *mut u8;
             core::ptr::write_bytes(entry.split, 0, used_bytes);
@@ -241,7 +242,7 @@ impl BuddyAlloc {
 
         // align base_addr to leaf size
         base_addr = roundup(base_addr, leaf2base);
-        assert!(end_addr >= base_addr, OOM_MSG);
+        assert!(end_addr >= base_addr, "{}", OOM_MSG);
         debug_assert_eq!(
             (base_addr >> leaf2base) << leaf2base,
             base_addr,


### PR DESCRIPTION
This PR changes the code so we can use `buddy-alloc` as a dependency when building std.

See how std [uses](https://github.com/rust-lang/rust/blob/81be7b86d348a5b7cad08386003c43d44d1e9f94/library/std/Cargo.toml#L40) dlmalloc, as well as dlmalloc's [Cargo.toml](https://github.com/alexcrichton/dlmalloc-rs/blob/f352ad5ea6546b95809dc154e9cf195fc740bc3e/Cargo.toml) file for an example.

This also resolves some errors triggered when panic message is not a string literal. My take is that an older Rust edition is used when building the Rust compiler / std library themselves.