### PR TITLE
perf: Tweaks to reduce cycle consumptions

### DIFF
--- a/src/tests/buddy_alloc.rs
+++ b/src/tests/buddy_alloc.rs
@@ -3,9 +3,17 @@ use crate::buddy_alloc::{block_size, BuddyAlloc, BuddyAllocParam, MIN_LEAF_SIZE_
 const HEAP_SIZE: usize = 1024 * 1024;
 const LEAF_SIZE: usize = MIN_LEAF_SIZE_ALIGN;
 
-fn with_allocator<F: FnOnce(BuddyAlloc)>(heap_size: usize, leaf_size: usize, f: F) {
+fn with_allocator<F: Fn(BuddyAlloc)>(heap_size: usize, leaf_size: usize, f: F) {
     let buf: Vec<u8> = Vec::with_capacity(heap_size);
     let param = BuddyAllocParam::new(buf.as_ptr(), heap_size, leaf_size);
+    unsafe {
+        let allocator = BuddyAlloc::new(param);
+        f(allocator);
+    }
+
+    let zero_filled_buf: Vec<u8> = vec![0; heap_size];
+    let param =
+        BuddyAllocParam::new_with_zero_filled(zero_filled_buf.as_ptr(), heap_size, leaf_size);
     unsafe {
         let allocator = BuddyAlloc::new(param);
         f(allocator);


### PR DESCRIPTION
This commit introduces 2 changes based on real observations to reduce cycle consumptions:

* FastAlloc would process the whole buffer into a double-linked list at initialization phase, however, a smart contract might only use a handful of the Nodes there. This commit changes the code so we are only initializating a constant number of nodes, and only create more nodes into the double-linked list when we needed. This also has the benefit that a bigger FastAlloc buffer can be used without cycle penalty.
* BuddyAlloc would always do memset on the memory buffer, however, in most cases, the buffer fed to BuddyAlloc is already zero-filled(such as ckb-std), this commit as a new param so we can skip the memset in BuddyAlloc, saving us the cycles used to memset buffers, which are not actually needed.