### PR TITLE
Use volatile to prevent the compiler from optimizing alias pointers

### DIFF
--- a/examples/non_threadsafe_demo.rs
+++ b/examples/non_threadsafe_demo.rs
@@ -4,17 +4,21 @@ const FAST_HEAP_SIZE: usize = 32 * 1024; // 32 KB
 const HEAP_SIZE: usize = 1024 * 1024; // 1M
 const LEAF_SIZE: usize = 16;
 
-pub static mut FAST_HEAP: [u8; FAST_HEAP_SIZE] = [0u8; FAST_HEAP_SIZE];
-pub static mut HEAP: [u8; HEAP_SIZE] = [0u8; HEAP_SIZE];
+#[repr(align(64))]
+struct Heap<const S: usize>([u8; S]);
+
+static mut FAST_HEAP: Heap<FAST_HEAP_SIZE> = Heap([0u8; FAST_HEAP_SIZE]);
+static mut HEAP: Heap<HEAP_SIZE> = Heap([0u8; HEAP_SIZE]);
 
 // This allocator can't work in tests since it's non-threadsafe.
 #[cfg_attr(not(test), global_allocator)]
 static ALLOC: NonThreadsafeAlloc = unsafe {
-    let fast_param = FastAllocParam::new(FAST_HEAP.as_ptr(), FAST_HEAP_SIZE);
-    let buddy_param = BuddyAllocParam::new(HEAP.as_ptr(), HEAP_SIZE, LEAF_SIZE);
+    let fast_param = FastAllocParam::new(FAST_HEAP.0.as_ptr(), FAST_HEAP_SIZE);
+    let buddy_param = BuddyAllocParam::new(HEAP.0.as_ptr(), HEAP_SIZE, LEAF_SIZE);
     NonThreadsafeAlloc::new(fast_param, buddy_param)
 };
 
+#[allow(clippy::useless_vec)]
 fn main() {
     let v = vec![0u8; 42];
     let msg = "alloc success".to_string();

--- a/examples/non_threadsafe_test.rs
+++ b/examples/non_threadsafe_test.rs
@@ -4,17 +4,21 @@ const FAST_HEAP_SIZE: usize = 32 * 1024; // 32 KB
 const HEAP_SIZE: usize = 1024 * 1024; // 1M
 const LEAF_SIZE: usize = 16;
 
-pub static mut FAST_HEAP: [u8; FAST_HEAP_SIZE] = [0u8; FAST_HEAP_SIZE];
-pub static mut HEAP: [u8; HEAP_SIZE] = [0u8; HEAP_SIZE];
+#[repr(align(64))]
+struct Heap<const S: usize>([u8; S]);
+
+static mut FAST_HEAP: Heap<FAST_HEAP_SIZE> = Heap([0u8; FAST_HEAP_SIZE]);
+static mut HEAP: Heap<HEAP_SIZE> = Heap([0u8; HEAP_SIZE]);
 
 // This allocator can't work in tests since it's non-threadsafe.
 #[cfg_attr(not(test), global_allocator)]
 static ALLOC: NonThreadsafeAlloc = unsafe {
-    let fast_param = FastAllocParam::new(FAST_HEAP.as_ptr(), FAST_HEAP_SIZE);
-    let buddy_param = BuddyAllocParam::new(HEAP.as_ptr(), HEAP_SIZE, LEAF_SIZE);
+    let fast_param = FastAllocParam::new(FAST_HEAP.0.as_ptr(), FAST_HEAP_SIZE);
+    let buddy_param = BuddyAllocParam::new(HEAP.0.as_ptr(), HEAP_SIZE, LEAF_SIZE);
     NonThreadsafeAlloc::new(fast_param, buddy_param)
 };
 
+#[allow(clippy::useless_vec)]
 fn main() {
     let v = vec![0u8; 32];
     drop(v);


### PR DESCRIPTION
Fix #16 

I suspect the compiler may have discarded line 44 due to optimizations, compiler ignoring the potential for pointer aliasing. I haven't confirmed from the disassembly, but this PR fixed the issue.

https://github.com/jjyr/buddy-alloc/blob/1a3e2e20234c3c2068dd5440c26339dd6cb6ab9c/src/fast_alloc.rs#L44-L45

I have also modified the code of buddy alloc to prevent potentially similiar errors.

After the fix, the performance even improved 8% ~ 10% on my macbook, it is because we removed a `write_unaligned`.