### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buddy-alloc"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Fixes #16 #17 

`0.5.2` is yanked, it requires memory arene align to 64 bytes which breaks the `0.5.x` users https://github.com/jjyr/buddy-alloc/issues/18#issuecomment-2413073000 .

We reintroduce this breaking change in this release `0.6.0`.